### PR TITLE
Feature: add support for any file encoding

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Localizer.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Localizer.xcscheme
@@ -61,20 +61,6 @@
             ReferencedContainer = "container:">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-         <CommandLineArgument
-            argument = "-l /Users/jaznar/desarrollo/tvsofa3/TVSofa3"
-            isEnabled = "YES">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "-v"
-            isEnabled = "YES">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "-s /Users/jaznar/desarrollo/tvsofa3"
-            isEnabled = "YES">
-         </CommandLineArgument>
-      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Localizer.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Localizer.xcscheme
@@ -61,6 +61,20 @@
             ReferencedContainer = "container:">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-l /Users/jaznar/desarrollo/tvsofa3/TVSofa3"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-v"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-s /Users/jaznar/desarrollo/tvsofa3"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Sources/Localizer/Data Models/Configuration/Configuration.swift
+++ b/Sources/Localizer/Data Models/Configuration/Configuration.swift
@@ -8,25 +8,19 @@
 import Foundation
 
 public struct Configuration {
-    public let localizableEncoding: String.Encoding
-    public let fileEncoding: String.Encoding
     public let formatsSupported: Set<String>
     public let capturePattern: String
     public let localizablesPattern: String
     
     public static var `default`: Configuration {
         return Configuration(
-            localizableEncoding: .utf8,
-            fileEncoding: .utf8,
             formatsSupported: [.swift, .objC],
             capturePattern: #"(?:.*\"(.*)\".localized)|NSLocalizedString\(\s*"([^"]+)"(?:\s*,|\s*comment:\s*"[^"]*"\s*\))"#,
             localizablesPattern: #"\"(.*)\".* ?="#
         )
     }
 
-    private init(localizableEncoding: String.Encoding, fileEncoding: String.Encoding, formatsSupported: [FormatsSupported], capturePattern: String, localizablesPattern: String) {
-        self.localizableEncoding = localizableEncoding
-        self.fileEncoding = fileEncoding
+    private init(formatsSupported: [FormatsSupported], capturePattern: String, localizablesPattern: String) {
         self.formatsSupported = Set<String>(formatsSupported.map{ $0.rawValue })
         self.capturePattern = capturePattern
         self.localizablesPattern = localizablesPattern

--- a/Sources/Localizer/Data Sources/Files/FilesDataSource.swift
+++ b/Sources/Localizer/Data Sources/Files/FilesDataSource.swift
@@ -11,6 +11,6 @@ import Files
 internal protocol FilesDataSource {
     func fetchFolders(fromPath path: String) throws -> Set<String>
     func fetchRecursiveFiles(fromPath path: String, extensions: Set<String>) throws -> Set<String>
-    func fetchFileContent(fromPath path: String, encoding: String.Encoding) throws -> String
+    func fetchFileContent(fromPath path: String) throws -> String
     func fetchFileData(fromPath path: String) throws -> Data
 }

--- a/Sources/Localizer/Data Sources/Files/FilesDataSourceImp.swift
+++ b/Sources/Localizer/Data Sources/Files/FilesDataSourceImp.swift
@@ -13,8 +13,8 @@ internal class FilesDataSourceImp: FilesDataSource {
         do {
             let folders = try Folder(path: path).subfolders.map{ $0.path }
             return Set<String>(folders)
-        } catch {
-            throw LocalizerError.invalidPath(path: path)
+        } catch let error {
+            throw error
         }
     }
     
@@ -26,24 +26,24 @@ internal class FilesDataSourceImp: FilesDataSource {
                 return files.map{ $0.path }
             }
             return Set<String>(filesPaths)
-        } catch {
-            throw LocalizerError.invalidPath(path: path)
+        } catch let error {
+            throw error
         }
     }
 
-    func fetchFileContent(fromPath path: String, encoding: String.Encoding) throws -> String {
+    func fetchFileContent(fromPath path: String) throws -> String {
         do {
-            return try File(path: path).readAsString(encodedAs: encoding)
-        } catch {
-            throw LocalizerError.invalidPath(path: path)
+            return try File(path: path).readAsString()
+        } catch let error {
+            throw error
         }
     }
     
     func fetchFileData(fromPath path: String) throws -> Data {
         do {
             return try File(path: path).read()
-        } catch {
-            throw LocalizerError.invalidPath(path: path)
+        } catch let error {
+            throw error
         }
     }
 }

--- a/Sources/Localizer/Data Sources/Localizables/LocalizablesDataSourceImp.swift
+++ b/Sources/Localizer/Data Sources/Localizables/LocalizablesDataSourceImp.swift
@@ -34,7 +34,7 @@ class LocalizablesDataSourceImp: LocalizablesDataSource {
                 if !languageLocalizable.localizables.contains(projectLocalizable) {
                     unlocalizableKeys.insert(projectLocalizable)
                     if parameters.verbose {
-                        print("Not found \"\(projectLocalizable)\" for '\(languageLocalizable.languageCode)' language")
+                        print("Not found \"\(projectLocalizable)\" for '\(languageLocalizable.languageCode.uppercased())' language")
                     }
                 }
             }
@@ -53,11 +53,7 @@ class LocalizablesDataSourceImp: LocalizablesDataSource {
         return try await withThrowingTaskGroup(of: LocalizablesResult.self) { taskGroup in
             languagesPath.forEach { languagePath in
                 taskGroup.addTask {
-                    do {
-                        return try await self.fetchLocalizableKeys(localizableFile: languagePath)
-                    } catch {
-                        return LocalizablesResult(languageCode: "", localizables: Set<String>())
-                    }
+                    return try await self.fetchLocalizableKeys(localizableFile: languagePath)
                 }
             }
             
@@ -81,7 +77,7 @@ class LocalizablesDataSourceImp: LocalizablesDataSource {
         do {
             fileContent = try String(contentsOfFile: "\(filePath)Localizable.strings")
         } catch let error {
-            print("Not found localizables for '\(languageCode)'. \(error)".red)
+            print("Not found localizables for '\(languageCode.uppercased())'. \(error)".red)
             return LocalizablesResult(languageCode: languageCode, localizables: Set<String>())
         }
         

--- a/Sources/Localizer/Data Sources/Project/ProjectDataSourceImp.swift
+++ b/Sources/Localizer/Data Sources/Project/ProjectDataSourceImp.swift
@@ -25,7 +25,6 @@ internal class ProjectDataSourceImp: ProjectDataSource {
                     return try await self.fetchLocalizableKeys(
                         fromPath: searchablePath,
                         extensions: self.configuration.formatsSupported,
-                        enconding: self.configuration.fileEncoding,
                         pattern: self.configuration.capturePattern
                     )
                 }
@@ -40,7 +39,7 @@ internal class ProjectDataSourceImp: ProjectDataSource {
         }
     }
     
-    private func fetchLocalizableKeys(fromPath path: String, extensions: Set<String>, enconding: String.Encoding, pattern: String) async throws -> Set<String> {
+    private func fetchLocalizableKeys(fromPath path: String, extensions: Set<String>, pattern: String) async throws -> Set<String> {
         return try await withThrowingTaskGroup(of: Set<String>.self) { taskGroup in
             let files = try filesDataSource.fetchRecursiveFiles(fromPath: path, extensions: extensions)
             
@@ -61,8 +60,7 @@ internal class ProjectDataSourceImp: ProjectDataSource {
     
     private func searchLocalizables(atFilePath filePath: String) async throws -> Set<String> {
         let fileContent = try filesDataSource.fetchFileContent(
-            fromPath: filePath,
-            encoding: configuration.fileEncoding
+            fromPath: filePath
         )
         
         let fileRange = NSRange(fileContent.startIndex..<fileContent.endIndex, in: fileContent)

--- a/Tests/LocalizerTests/FileDataSourceTests.swift
+++ b/Tests/LocalizerTests/FileDataSourceTests.swift
@@ -33,7 +33,7 @@ class FileDataSourceTests: XCTestCase {
         }
 
         do {
-            let fileContent = try sut.fetchFileContent(fromPath: filePath, encoding: .utf8)
+            let fileContent = try sut.fetchFileContent(fromPath: filePath)
 
             XCTAssertNotNil(fileContent)
             XCTAssertTrue(fileContent.contains("Hello world!"))
@@ -43,6 +43,6 @@ class FileDataSourceTests: XCTestCase {
     }
     
     func testFetchInvalidFile() {
-        XCTAssertThrowsError(try sut.fetchFileContent(fromPath: "../Resources/unexpected.txt", encoding: .utf8))
+        XCTAssertThrowsError(try sut.fetchFileContent(fromPath: "../Resources/unexpected.txt"))
     }
 }


### PR DESCRIPTION
In this Pull Request we have added support for any file encoding, allowing users to have their localizable files in any encoding such as utf8, utf16, ascii, etc.

Code changes made in this Pull Request:

- Detect file encoding automatically from the Localized files.
- Removed file encoding parameter from configuration class